### PR TITLE
Fix/Setting programatically non-formatted text

### DIFF
--- a/FormattableTextView/FormattableInput.swift
+++ b/FormattableTextView/FormattableInput.swift
@@ -405,10 +405,11 @@ extension FormattableInputInternal {
 public extension FormattableInput {
 	var formattedText: String? {
 		get {
-			guard let currentFormat = currentFormat else {
-				return nil
-			}
 			var text = text(in: textRange(from: self.beginningOfDocument, to: self.endOfDocument) ?? UITextRange()) ?? ""
+            guard let currentFormat = currentFormat else {
+                return text
+            }
+
 			var result = ""
 			
 			var shouldBreakLoopForLeftAndRight = false

--- a/FormattableTextView/FormattableInput.swift
+++ b/FormattableTextView/FormattableInput.swift
@@ -406,9 +406,9 @@ public extension FormattableInput {
 	var formattedText: String? {
 		get {
 			var text = text(in: textRange(from: self.beginningOfDocument, to: self.endOfDocument) ?? UITextRange()) ?? ""
-            guard let currentFormat = currentFormat else {
-                return text
-            }
+			guard let currentFormat = currentFormat else {
+				return text
+			}
 
 			var result = ""
 			

--- a/FormattableTextView/FormattableKernTextView.swift
+++ b/FormattableTextView/FormattableKernTextView.swift
@@ -73,6 +73,8 @@ open class FormattableKernTextView: UITextView, FormattableInput, FormattableInp
 		switch result {
 		case .allowed(let attributedString, let numberOfDeletedSymbols, let maskLayersDiff):
 			setAttributedTextAndTextPosition(attributedString: attributedString, location: range.location, offset: text.count-numberOfDeletedSymbols, maskLayersDiff: maskLayersDiff)
+        case .withoutFormat:
+            super.text = (super.text as NSString?)?.replacingCharacters(in: range, with: text)
 		default:
 			break
 		}

--- a/FormattableTextView/FormattableKernTextView.swift
+++ b/FormattableTextView/FormattableKernTextView.swift
@@ -73,8 +73,8 @@ open class FormattableKernTextView: UITextView, FormattableInput, FormattableInp
 		switch result {
 		case .allowed(let attributedString, let numberOfDeletedSymbols, let maskLayersDiff):
 			setAttributedTextAndTextPosition(attributedString: attributedString, location: range.location, offset: text.count-numberOfDeletedSymbols, maskLayersDiff: maskLayersDiff)
-        case .withoutFormat:
-            super.text = (super.text as NSString?)?.replacingCharacters(in: range, with: text)
+		case .withoutFormat:
+			super.text = (super.text as NSString?)?.replacingCharacters(in: range, with: text)
 		default:
 			break
 		}

--- a/FormattableTextView/FormattableTextField.swift
+++ b/FormattableTextView/FormattableTextField.swift
@@ -149,8 +149,8 @@ open class FormattableTextField: UITextField, FormattableInput, FormattableInput
 		case .allowed(let attributedString, let numberOfDeletedSymbols, let maskLayersDiff):
 			setAttributedTextAndTextPosition(attributedString: attributedString, location: range.location, offset: text.count-numberOfDeletedSymbols, maskLayersDiff: maskLayersDiff)
 			self.sendActions(for: .editingChanged)
-        case .withoutFormat:
-            super.text = (super.text as NSString?)?.replacingCharacters(in: range, with: text)
+		case .withoutFormat:
+			super.text = (super.text as NSString?)?.replacingCharacters(in: range, with: text)
 		default:
 			break
 		}

--- a/FormattableTextView/FormattableTextField.swift
+++ b/FormattableTextView/FormattableTextField.swift
@@ -149,6 +149,8 @@ open class FormattableTextField: UITextField, FormattableInput, FormattableInput
 		case .allowed(let attributedString, let numberOfDeletedSymbols, let maskLayersDiff):
 			setAttributedTextAndTextPosition(attributedString: attributedString, location: range.location, offset: text.count-numberOfDeletedSymbols, maskLayersDiff: maskLayersDiff)
 			self.sendActions(for: .editingChanged)
+        case .withoutFormat:
+            super.text = (super.text as NSString?)?.replacingCharacters(in: range, with: text)
 		default:
 			break
 		}

--- a/FormattableTextViewTests/FormattableTextTests.swift
+++ b/FormattableTextViewTests/FormattableTextTests.swift
@@ -65,4 +65,12 @@ class FormattableTextTests: XCTestCase {
         let result = tv.formattedText
         XCTAssertEqual(result, "non-formatted text")
     }
+
+    func testNonFormattedTextInTextField() throws {
+        let tv = FormattableTextField()
+        tv.text = "non-formatted text"
+
+        let result = tv.formattedText
+        XCTAssertEqual(result, "non-formatted text")
+    }
 }

--- a/FormattableTextViewTests/FormattableTextTests.swift
+++ b/FormattableTextViewTests/FormattableTextTests.swift
@@ -58,11 +58,11 @@ class FormattableTextTests: XCTestCase {
 		XCTAssertEqual(result, "t(459-_*asdf")
 	}
 
-    func testNonFormattedTextInTextView() throws {
-        let tv = FormattableKernTextView()
-        tv.text = "non-formatted text"
+	func testNonFormattedTextInTextView() throws {
+		let tv = FormattableKernTextView()
+		tv.text = "non-formatted text"
 
-        let result = tv.formattedText
-        XCTAssertEqual(result, "non-formatted text")
-    }
+		let result = tv.formattedText
+		XCTAssertEqual(result, "non-formatted text")
+	}
 }

--- a/FormattableTextViewTests/FormattableTextTests.swift
+++ b/FormattableTextViewTests/FormattableTextTests.swift
@@ -58,4 +58,11 @@ class FormattableTextTests: XCTestCase {
 		XCTAssertEqual(result, "t(459-_*asdf")
 	}
 
+    func testNonFormattedTextInTextView() throws {
+        let tv = FormattableKernTextView()
+        tv.text = "non-formatted text"
+
+        let result = tv.formattedText
+        XCTAssertEqual(result, "non-formatted text")
+    }
 }


### PR DESCRIPTION
I am using a `FormattableTextField` in a screen where, depending on the users' preference, sometimes it's configured as having a format and othertimes it's just a normal, non-formatted input. I observed that when I configure it as non-formatted (i.e. without any `formats` set), setting programatically a `text` on it *doesn't* display anything.

This PR aims to fix this so this the `FormattableTextField` field can be used exactly like a normal `UITextField` when there are no `formats` set.
The change is covered by Unit Tests.